### PR TITLE
Ensure hockeypuck server has no unexpected arguments

### DIFF
--- a/cmd/hockeypuck/main.go
+++ b/cmd/hockeypuck/main.go
@@ -22,6 +22,11 @@ var (
 func main() {
 	flag.Parse()
 
+	if len(flag.Args()) != 0 {
+		flag.Usage()
+		cmd.Die(errgo.New("unexpected command line arguments"))
+	}
+
 	var (
 		settings *server.Settings
 		err      error


### PR DESCRIPTION
Otherwise running `hockeypuck -config ~/hk.conf \*.pgp` (as documented) will result in
it starting and not doing anything with the `\*.pgp` argument.